### PR TITLE
Change wallet-rpc port to 18083

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       "--password",
       "${MONERO_WALLET_PASSWORD}",
       "--rpc-bind-port",
-      "28081",
+      "18083",
       "--daemon-host",
       "${MONERO_DAEMON_RPC_HOSTNAME}",
       "--daemon-port",

--- a/nerostr/main.go
+++ b/nerostr/main.go
@@ -24,7 +24,7 @@ func main() {
 	apiKey := flag.String("api-key", "", "api key")
 	listenAddr := flag.String("listen", ":8080", "server listen address")
 	rootDir := flag.String("root", "/app/", "root directory")
-	xmrWalletRpc := flag.String("monero-wallet-rpc-url", "http://monero-wallet-rpc:28081/json_rpc", "url for the monero rpc server")
+	xmrWalletRpc := flag.String("monero-wallet-rpc-url", "http://monero-wallet-rpc:18083/json_rpc", "url for the monero rpc server")
 	nerostrHost := flag.String("host-domain", "localhost:8080", "nerostr host")
 	dev := flag.Bool("dev", false, "development mode")
 	testnet := flag.Bool("testnet", false, "use testnet")


### PR DESCRIPTION
Hey Pluja, you set the wallet rpc port to 28081, but the container always exposed port 18083. I don't know why this happens.

Maybe because there is no port mapping?

SethForPrivacy Exposes Port 18083 in his [Dockerfile](https://github.com/sethforprivacy/simple-monero-wallet-rpc-docker/blob/main/Dockerfile#L183).